### PR TITLE
Proxies images through the Replicated proxy

### DIFF
--- a/templates/registry-secret.yaml
+++ b/templates/registry-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: replicated-registry 
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.global.replicated.dockerconfigjson }}
+

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@
 ## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
 global:
-  imageRegistry: ""
+  imageRegistry: proxy.replicated.com/proxy/gitea-platypus
   ## E.g.
   ## imagePullSecrets:
   ##   - myRegistryKeySecretName

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,8 @@ global:
   ## imagePullSecrets:
   ##   - myRegistryKeySecretName
   ##
-  imagePullSecrets: []
+  imagePullSecrets: 
+  - replicated-registry
   storageClass: ""
 
 ## @section Common parameters


### PR DESCRIPTION
TL;DR
-----

Uses the Replicated proxy registry

Details
-------

Proxies images through the Replicated proxy registry and adds the required
image pull secret. Right now the secret is named `replicated-registry` since it
the Bitnami common library forces us to specify a static name in
`global.imagePullSeecrets`. This was the quickest way to get it going and
remain idiomatic to the way Bitnami does thingss, but it makes the secret
inconsistent with the usually naming Bitnami naming conventions.

