### PR TITLE
Continuously deliver to the Replicated Platform with GitHub or GitLab

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Get short SHA sum
       id: get-short-rev
       shell: bash
-      run: echo "short-shar=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      run: echo "short-rev=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
     - name: Get the expected chart version
-      id: get_chart_version
+      id: get-chart-version
       uses: mikefarah/yq@master
       with:
         cmd: yq '.version' Chart.yaml
@@ -41,7 +41,7 @@ jobs:
         echo "package=gitea-${version}.tgz" >> $GITHUB_OUTPUT
       env:
         CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
-        SHORT_SHA: ${{ steps.get-short-sha.outputs.short-sha }}
+        SHORT_SHA: ${{ steps.get-short-rev.outputs.short-rev }}
 
   # Create a Replicated release without promoting to a channel. The Replicated
   # CLI isn't super scripting friendly when it comes to creating releases, so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       id: package-helm-chart
       run: |
         mkdir -p release
-        version=${{ steps.get-chart-version.outputs.result }}-build+${{ steps.get-short-sha.outputs.short-sha }}
+        version=${{ steps.get-chart-version.outputs.result }}+build.${{ steps.get-short-sha.outputs.short-sha }}
         helm package . --version="${version}" -u 
         echo "package=gitea-${version}.tgz" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,8 @@ jobs:
                       | jq --arg slug ${REPLICATED_APP} '.apps[] | select ( .slug == $slug ) | .id')
         echo "app-id=${app_id}" >> $GITHUB_OUTPUT
       env:
-        REPLICATED_API_TOKEN: ${{ inputs.api-token }}
-        REPLICATED_APP: ${{ inputs.app-slug }}
+        REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
+        REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
     - name: Encode Helm chart
       id: encode-chart
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Create Release
         id: create-release
-        uses: replicatedhq/compatibility-actions/create-release@feature/crdant/flexible-create-release
+        uses: replicatedhq/compatibility-actions/create-release@feature/crdant/flexibile-create-release
         with:
           app-slug: ${{ secrets.REPLICATED_APP }}
           api-token: ${{ secrets.REPLICATED_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Create the release
       id: create-release
       run: |
-        body=$(jq --arg spec_gzip "${SPEC_GZIP}" '{ "spec_gzip": $spec_gzip }'
+        body=$(jq --arg spec_gzip "${SPEC_GZIP}" '{ "spec_gzip": $spec_gzip }')
         sequence=$(curl --location "https://api.replicated.com/vendor/v3/app/${APP_ID}/release" \
                       --header 'Content-Type: application/json' \
                       --header 'Accept: application/json' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,8 @@ jobs:
   package-chart:
     runs-on: ubuntu-latest
     outputs:
-      package: ${{ steps.package-helm-chart.outputs.package }}
+      chart: ${{ steps.package-chart.outputs.package }}
+      content: ${{ steps.encode-chart.outputs.content }}
     steps:
     - uses: actions/checkout@v3
     - name: Get release channel
@@ -41,6 +42,12 @@ jobs:
       env:
         CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
         SHORT_SHA: ${{ steps.get-short-rev.outputs.short-rev }}
+    - name: Encode Helm chart
+      id: encode-chart
+      run: |
+        echo "content=$(base64 -w 0 ${CHART})" >> $GITHUB_OUTPUT
+      env: 
+        CHART: ${{ steps.package-chart.outputs.package }}
 
   # Create a Replicated release without promoting to a channel. The Replicated
   # CLI isn't super scripting friendly when it comes to creating releases, so
@@ -64,12 +71,6 @@ jobs:
       env:
         REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
         REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
-    - name: Encode Helm chart
-      id: encode-chart
-      run: |
-        echo "content=$(base64 -w 0 ${CHART})" >> $GITHUB_OUTPUT
-      env: 
-        CHART: ${{ needs.package-chart.outputs.package }}
     - name: Prepare release spec
       id: prepare-spec
       run: |
@@ -79,7 +80,7 @@ jobs:
         echo "spec_gzip=${spec_gzip}" >> $GITHUB_OUTPUT
       env:
         CHART: ${{ needs.package-chart.outputs.package }}
-        CONTENT: ${{ steps.encode-chart.outputs.content }}
+        CONTENT: ${{ needs.package.outputs.content }}
     - name: Create the release
       id: create-release
       run: |
@@ -114,5 +115,3 @@ jobs:
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
-
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         id: promote-release
         uses: docker://replicated/vendor-cli:latest
         with:
-          args: release promote ${{ steps.create-release.outputs.sequence }} ${{ steps.get-channel.outputs.channel }}
+          args: release promote ${{ needs.create-release.outputs.sequence }} ${{ steps.get-channel.outputs.channel }}
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         echo "content=$(base64 -w 0 ${CHART})" >> $GITHUB_OUTPUT
       env: 
-        CHART: ${{ inputs.chart }}
+        CHART: ${{ needs.package-chart.outputs.chart }}
     - name: Prepare release spec
       id: prepare-spec
       run: |
@@ -78,7 +78,7 @@ jobs:
           | base64)
         echo "spec_gzip=${spec_gzip}" >> $GITHUB_OUTPUT
       env:
-        CHART: ${{ inputs.chart }}
+        CHART: ${{ needs.package-chart.outputs.chart }}
         CONTENT: ${{ steps.encode-chart.outputs.content }}
     - name: Create the release
       id: create-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         CHART: ${{ inputs.chart }}
     - name: Prepare release spec
       id: prepare-spec
-      run:
+      run: |
         spec_gzip=$(jq --arg chart "${CHART}" --arg content "${CONTENT}" '[{ "name": $chart, "path": $chart, "content": $content }]' \
           | gzip --to-stdout \
           | base64)
@@ -80,7 +80,7 @@ jobs:
         CONTENT: ${{ step.encode-chart.outputs.content }}
     - name: Create the release
       id: create-release
-      run:
+      run: |
         body=$(jq --arg spec_gzip "${SPEC_GZIP}" '{ "spec_gzip": $spec_gzip }'
         sequence=$(curl --location "https://api.replicated.com/vendor/v3/app/${APP_ID}/release" \
                       --header 'Content-Type: application/json' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         # use the reoplicated api and filter down the reults to get the applicationm ID
         # based on the providded app slug
-        app_id = $(curl --location 'https://api.replicated.com/vendor/v3/apps' \
+        app_id=$(curl --location 'https://api.replicated.com/vendor/v3/apps' \
                         --header 'Accept: application/json' \
                         --header "Authorization: ${REPLICATED_API_TOKEN}" \
                       | jq --arg slug ${REPLICATED_APP} '.apps[] | select ( .slug == $slug ) | .id')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,12 @@ jobs:
       id: package-helm-chart
       run: |
         mkdir -p release
-        version=${{ steps.get-chart-version.outputs.result }}+build.${{ steps.get-short-sha.outputs.short-sha }}
+        version="${CHART_VERSION}.build.${SHORT_SHA}"
         helm package . --version="${version}" -u 
         echo "package=gitea-${version}.tgz" >> $GITHUB_OUTPUT
+      env:
+        CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
+        SHORT_SHA: ${{ steps.get-short-sha.outputs.short-sha }}
 
   # Create a Replicated release without promoting to a channel. The Replicated
   # CLI isn't super scripting friendly when it comes to creating releases, so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         cmd: yq '.version' Chart.yaml
     - name: Package Helm chart with a build-specific version
-      id: package-helm-chart
+      id: package-chart
       run: |
         version="${CHART_VERSION}.build.${SHORT_SHA}"
         helm package . --version="${version}" -u 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package-chart
     outputs:
-      sequence: ${{ steps.create-release.outputs.release_sequence }}
+      sequence: ${{ steps.create-release.outputs.release-sequence }}
     steps:
       - name: Download chart artifact
         id: get-chart
@@ -63,7 +63,6 @@ jobs:
         with:
           name: chart
           path: ${{ needs.package-chart.outputs.chart }}
-
       - name: Create Release
         id: create-release
         uses: replicatedhq/compatibility-actions/create-release@feature/crdant/flexibile-create-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,8 +79,8 @@ jobs:
           | base64)
         echo "spec_gzip=${spec_gzip}" >> $GITHUB_OUTPUT
       env:
-        CHART: ${{ needs.package-chart.outputs.package }}
-        CONTENT: ${{ needs.package.outputs.content }}
+        CHART: ${{ needs.package-chart.outputs.chart }}
+        CONTENT: ${{ needs.package-chart.outputs.content }}
     - name: Create the release
       id: create-release
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
     - name: Package Helm chart with a build-specific version
       id: package-helm-chart
       run: |
-        mkdir -p release
         version="${CHART_VERSION}.build.${SHORT_SHA}"
         helm package . --version="${version}" -u 
         echo "package=gitea-${version}.tgz" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         echo "content=$(base64 -w 0 ${CHART})" >> $GITHUB_OUTPUT
       env: 
-        CHART: ${{ needs.package-chart.outputs.chart }}
+        CHART: ${{ needs.package-chart.outputs.package }}
     - name: Prepare release spec
       id: prepare-spec
       run: |
@@ -78,7 +78,7 @@ jobs:
           | base64)
         echo "spec_gzip=${spec_gzip}" >> $GITHUB_OUTPUT
       env:
-        CHART: ${{ needs.package-chart.outputs.chart }}
+        CHART: ${{ needs.package-chart.outputs.package }}
         CONTENT: ${{ steps.encode-chart.outputs.content }}
     - name: Create the release
       id: create-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       chart: ${{ steps.package-chart.outputs.package }}
-      content: ${{ steps.encode-chart.outputs.content }}
     steps:
     - uses: actions/checkout@v3
     - name: Get release channel
@@ -42,13 +41,13 @@ jobs:
       env:
         CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
         SHORT_SHA: ${{ steps.get-short-rev.outputs.short-rev }}
-    - name: Encode Helm chart
-      id: encode-chart
-      run: |
-        echo "content=$(base64 -w 0 ${CHART})" >> $GITHUB_OUTPUT
-      env: 
-        CHART: ${{ steps.package-chart.outputs.package }}
-
+    - name: Upload chart artifact
+      id: uplaad-chart
+      uses: actions/upload-artifact@master
+      with:
+        name: chart
+        path: ${{ steps.package-chart.outputs.package }}
+          
   # Create a Replicated release without promoting to a channel. The Replicated
   # CLI isn't super scripting friendly when it comes to creating releases, so
   # this job uses a few different calls with curl instead.
@@ -56,45 +55,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: package-chart
     outputs:
-      sequence: ${{ steps.create-release.outputs.sequence }}
+      sequence: ${{ steps.create-release.outputs.release_sequence }}
     steps:
-    - name: Get the application ID
-      id: get-app-id
-      run: |
-        # use the reoplicated api and filter down the reults to get the applicationm ID
-        # based on the providded app slug
-        app_id=$(curl --location 'https://api.replicated.com/vendor/v3/apps' \
-                        --header 'Accept: application/json' \
-                        --header "Authorization: ${REPLICATED_API_TOKEN}" \
-                      | jq --arg slug ${REPLICATED_APP} '.apps[] | select ( .slug == $slug ) | .id')
-        echo "app-id=${app_id}" >> $GITHUB_OUTPUT
-      env:
-        REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
-        REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
-    - name: Prepare release spec
-      id: prepare-spec
-      run: |
-        spec_gzip=$(jq --arg chart "${CHART}" --arg content "${CONTENT}" '[{ "name": $chart, "path": $chart, "content": $content }]' \
-          | gzip --to-stdout \
-          | base64)
-        echo "spec_gzip=${spec_gzip}" >> $GITHUB_OUTPUT
-      env:
-        CHART: ${{ needs.package-chart.outputs.chart }}
-        CONTENT: ${{ needs.package-chart.outputs.content }}
-    - name: Create the release
-      id: create-release
-      run: |
-        body=$(jq --arg spec_gzip "${SPEC_GZIP}" '{ "spec_gzip": $spec_gzip }')
-        sequence=$(curl --location "https://api.replicated.com/vendor/v3/app/${APP_ID}/release" \
-                      --header 'Content-Type: application/json' \
-                      --header 'Accept: application/json' \
-                      --header "Authorization: ${REPLICATED_API_TOKEN}" \
-                      --data "${body}" \
-                    | jq .release.sequence )
-        echo "sequence=${sequence}" >> $GITHUB_OUTPUT
-      env:
-        SPEC_GZIP: ${{ steps.prepare-spec.outputs.spec_gzip }}
+      - name: Download chart artifact
+        id: get-chart
+        uses: actions/download-artifact@master
+        with:
+          name: chart
+          path: ${{ needs.package-chart.outputs.chart }}
 
+      - name: Create Release
+        id: create-release
+        uses: replicatedhq/compatibility-actions/create-release@feature/crdant/flexible-create-release
+        with:
+          app-slug: ${{ secrets.REPLICATED_APP }}
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          chart: ${{ needs.package-chart.outputs.chart }}
+       
   promote-release:
     runs-on: ubuntu-latest
     needs: create-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,116 @@
+name: Continuous Delivery to the Replicated platform
+
+on:
+  push:
+    paths:
+    - '**'
+    - '!**.md'
+    - '!doc/**'
+    - '!**.png'
+
+jobs:
+  package-chart:
+    runs-on: ubuntu-latest
+    outputs:
+      package: ${{ step.package-helm-chart.outputs.package }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get release channel
+      id: get-channel
+      shell: bash
+      run: |
+        if [[ ${GITHUB_REF_NAME} == "main" ]] ; then
+          echo "channel=Unstable" >> $GITHUB_OUTPUT
+        fi 
+        echo "channel=${GITHUB_REF_NAME}"
+    - name: Get short SHA sum
+      id: get-short-rev
+      shell: bash
+      run: echo "short-shar=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+    - name: Get the expected chart version
+      id: get_chart_version
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq '.version' Chart.yaml
+    - name: Package Helm chart with a build-specific version
+      id: package-helm-chart
+      run: |
+        mkdir -p release
+        version=${{ steps.get-chart-version.outputs.result }}-build+${{ steps.get-short-sha.outputs.short-sha }}
+        helm package . --version="${version}" -u 
+        echo "package=gitea-${version}.tgz" >> $GITHUB_OUTPUT
+
+  # Create a Replicated release without promoting to a channel. The Replicated
+  # CLI isn't super scripting friendly when it comes to creating releases, so
+  # this job uses a few different calls with curl instead.
+  create-release:
+    runs-on: ubuntu-latest
+    needs: package-chart
+    outputs:
+      sequence: ${{ steps.create-release.outputs.sequence }}
+    steps:
+    - name: Get the application ID
+      id: get-app-id
+      run: |
+        # use the reoplicated api and filter down the reults to get the applicationm ID
+        # based on the providded app slug
+        app_id = $(curl --location 'https://api.replicated.com/vendor/v3/apps' \
+                        --header 'Accept: application/json' \
+                        --header "Authorization: ${REPLICATED_API_TOKEN}" \
+                      | jq --arg slug ${REPLICATED_APP} '.apps[] | select ( .slug == $slug ) | .id')
+        echo "app-id=${app_id}" >> $GITHUB_OUTPUT
+      env:
+        REPLICATED_API_TOKEN: ${{ inputs.api-token }}
+        REPLICATED_APP: ${{ inputs.app-slug }}
+    - name: Encode Helm chart
+      id: encode-chart
+      run: |
+        echo "content=$(base64 -w 0 ${CHART})" >> $GITHUB_OUTPUT
+      env: 
+        CHART: ${{ inputs.chart }}
+    - name: Prepare release spec
+      id: prepare-spec
+      run:
+        spec_gzip=$(jq --arg chart "${CHART}" --arg content "${CONTENT}" '[{ "name": $chart, "path": $chart, "content": $content }]' \
+          | gzip --to-stdout \
+          | base64)
+        echo "spec_gzip=${spec_gzip}" >> $GITHUB_OUTPUT
+      env:
+        CHART: ${{ inputs.chart }}
+        CONTENT: ${{ step.encode-chart.outputs.content }}
+    - name: Create the release
+      id: create-release
+      run:
+        body=$(jq --arg spec_gzip "${SPEC_GZIP}" '{ "spec_gzip": $spec_gzip }'
+        sequence=$(curl --location "https://api.replicated.com/vendor/v3/app/${APP_ID}/release" \
+                      --header 'Content-Type: application/json' \
+                      --header 'Accept: application/json' \
+                      --header "Authorization: ${REPLICATED_API_TOKEN}" \
+                      --data "${body}" \
+                    | jq .release.sequence )
+        echo "sequence=${sequence}" >> $GITHUB_OUTPUT
+      env:
+        SPEC_GZIP: ${{ step.prepare-spec.outputs.spec_gzip }}
+
+  promote-release:
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get the channel for the release
+        id: get-channel
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == "main" ]] ; then 
+            echo "channel=Unstable" >> $GITHUB_OUTPUT
+          fi
+          echo "channel=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+      - name: Promote the release
+        id: promote-release
+        uses: docker://replicated/vendor-cli:latest
+        with:
+          args: release promote ${{ steps.create-release.outputs.sequence }} ${{ steps.get-channel.outputs.channel }}
+        env:
+          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
+          REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   package-chart:
     runs-on: ubuntu-latest
     outputs:
-      package: ${{ step.package-helm-chart.outputs.package }}
+      package: ${{ steps.package-helm-chart.outputs.package }}
     steps:
     - uses: actions/checkout@v3
     - name: Get release channel
@@ -77,7 +77,7 @@ jobs:
         echo "spec_gzip=${spec_gzip}" >> $GITHUB_OUTPUT
       env:
         CHART: ${{ inputs.chart }}
-        CONTENT: ${{ step.encode-chart.outputs.content }}
+        CONTENT: ${{ steps.encode-chart.outputs.content }}
     - name: Create the release
       id: create-release
       run: |
@@ -90,7 +90,7 @@ jobs:
                     | jq .release.sequence )
         echo "sequence=${sequence}" >> $GITHUB_OUTPUT
       env:
-        SPEC_GZIP: ${{ step.prepare-spec.outputs.spec_gzip }}
+        SPEC_GZIP: ${{ steps.prepare-spec.outputs.spec_gzip }}
 
   promote-release:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:          # List of stages for jobs, and their order of execution
   dependencies:
     - 'Package Chart'
   image:
-    name: nixery.dev/shell/curl/jq/gnugrep
+    name: nixery.dev/shell/gnugrep/gzip/curl/jq/yq-go
   script:
     - |
       chart=$(ls ./*.tgz)
@@ -35,7 +35,7 @@ stages:          # List of stages for jobs, and their order of execution
                     --header 'Content-Type: application/json' \
                     --header 'Accept: application/json' \
                     --header "Authorization: ${REPLICATED_API_TOKEN}" \
-                    --data "$(jq --null-input --compact-output --rawfile spec_gzip spec.gz '{ "spec_gzip", $spec_gzip }')" \
+                    --data @<(jq --null-input --compact-output --rawfile spec_gzip spec.gz '{ "spec_gzip", $spec_gzip }') \
                     --silent --show-error \
                   | jq --compact-output '{ "sequence": .release.sequence }')"
       echo "SEQUENCE=${sequence}" > release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,38 @@
+stages:          # List of stages for jobs, and their order of execution
+  - setup
+  - package
+  - release
+  - promote
+
+'Package Chart':      # Package with Helm
+  stage: package
+  image: 
+    name: cgr.dev/chainguard/helm:latest
+    entrypoint: [""] # This is a must. Entrypoint must be overriden to allow the script part to work. Script can not be skipped for the pipeline spec.
+  script:
+    - helm package -u . # As the entrypoint is skipped, specifying the entire command.
+  artifacts:
+    paths:
+      - "**/*.tgz"
+
+'Create Release':      # Create the release 
+  stage: release
+  dependencies:
+    - 'Package with Helm'
+  service:
+    name: replicated/vendor-cli:latest
+    entrypoint: [""] # This is a must. Entrypoint must be overriden to allow the script part to work. Script can not be skipped for the pipeline spec.
+  script:
+    - /replicated release create --auto -y # As the entrypoint is skipped, specifying the entire command.
+
+'Promote Release':      # Promote the release to the appropriate channel
+  stage: promote
+  dependencies:
+    - 'Create Release'
+  service: 
+    name: replicated/vendor-cli:latest
+    entrypoint: [""] # This is a must. Entrypoint must be overriden to allow the script part to work. Script can not be skipped for the pipeline spec.
+  script:
+    - /replicated release promote 
+
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,23 +19,25 @@ stages:          # List of stages for jobs, and their order of execution
   dependencies:
     - 'Package Chart'
   image:
-    name: nixery.dev/shell/curl/jq
+    name: nixery.dev/shell/curl/jq/gnugrep
   script:
     - |
       chart=$(ls ./*.tgz)
       app_id="$(curl --location 'https://api.replicated.com/vendor/v3/apps' \
                    --header 'Accept: application/json' \
                    --header "Authorization: ${REPLICATED_API_TOKEN}" \
+                   --silent --show-error \
                 | jq --raw-output --arg slug ${REPLICATED_APP} '.apps[] | select ( .slug == $slug ) | .id')"
-      spec_gzip="$(jq --compact --null-input --arg chart ${chart} --rawfile content <(base64 -w 0 ${chart}) '[ {"name": $chart, "path": $chart, "content": $content}]' | \
+      jq --null-input --compact-output --arg chart ${chart} --rawfile content <(base64 -w 0 ${chart}) '[ {"name": $chart, "path": $chart, "content": $content}]' \
         | gzip --to-stdout \
-        | base64 -w 0)"
+        | base64 -w 0 > spec.gz
       sequence="$(curl --location "https://api.replicated.com/vendor/v3/app/${app_id}/release" \
                     --header 'Content-Type: application/json' \
                     --header 'Accept: application/json' \
                     --header "Authorization: ${REPLICATED_API_TOKEN}" \
-                    --data "$(jq --compact --null-input --arg spec_gzip "${spec_gzip}" '{ "spec_gzip", $spec_gzip }')" \
-                  | jq '{ "sequence": .sequence }')"
+                    --data "$(jq --null-input --compact-output --rawfile spec_gzip spec.gz '{ "spec_gzip", $spec_gzip }')" \
+                    --silent --show-error \
+                  | jq --compact-output '{ "sequence": .release.sequence }')"
       echo "SEQUENCE=${sequence}" > release.env
   artifacts:
     reports:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,8 @@ stages:          # List of stages for jobs, and their order of execution
   stage: release
   dependencies:
     - 'Package Chart'
+  image:
+    name: nixery.dev/shell/curl/jq
   script:
     - |
       chart=$(ls ./*.tgz)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ stages:          # List of stages for jobs, and their order of execution
     entrypoint: [""]
   script:
     - |
+      set -euxo pipefail
       chart=$(ls ./*.tgz)
       app_id="$(curl --location 'https://api.replicated.com/vendor/v3/apps' \
                    --header 'Accept: application/json' \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ stages:          # List of stages for jobs, and their order of execution
     - 'Package Chart'
   image:
     name: nixery.dev/shell/gnugrep/gzip/curl/jq/yq-go
+    entrypoint: [""]
   script:
     - |
       chart=$(ls ./*.tgz)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ stages:          # List of stages for jobs, and their order of execution
                     --header "Authorization: ${REPLICATED_API_TOKEN}" \
                     --data @<(jq --null-input --compact-output --rawfile spec_gzip spec.gz '{ "spec_gzip", $spec_gzip }') \
                     --silent --show-error \
-                  | jq --compact-output '{ "sequence": .release.sequence }')"
+                  | jq --compact-output '.release.sequence')"
       echo "SEQUENCE=${sequence}" > release.env
   artifacts:
     reports:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:          # List of stages for jobs, and their order of execution
 'Package Chart':      # Package with Helm
   stage: package
   image: 
-    name: cgr.dev/chainguard/helm:latest
+    name: dtzar/helm-kubectl:3.12.2
     entrypoint: [""] # This is a must. Entrypoint must be overriden to allow the script part to work. Script can not be skipped for the pipeline spec.
   script:
     - helm package -u . # As the entrypoint is skipped, specifying the entire command.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ stages:          # List of stages for jobs, and their order of execution
 'Create Release':      # Create the release 
   stage: release
   dependencies:
-    - 'Package with Helm'
+    - 'Package Chart'
   script:
     - |
       chart=$(ls ./*.tgz)
@@ -39,7 +39,6 @@ stages:          # List of stages for jobs, and their order of execution
     reports:
       dotenv: release.env
   
-
 'Promote Release':      # Promote the release to the appropriate channel
   stage: promote
   dependencies:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 stages:          # List of stages for jobs, and their order of execution
-  - setup
   - package
   - release
   - promote
@@ -19,20 +18,36 @@ stages:          # List of stages for jobs, and their order of execution
   stage: release
   dependencies:
     - 'Package with Helm'
-  service:
-    name: replicated/vendor-cli:latest
-    entrypoint: [""] # This is a must. Entrypoint must be overriden to allow the script part to work. Script can not be skipped for the pipeline spec.
   script:
-    - /replicated release create --auto -y # As the entrypoint is skipped, specifying the entire command.
+    - |
+      chart=$(ls ./*.tgz)
+      app_id="$(curl --location 'https://api.replicated.com/vendor/v3/apps' \
+                   --header 'Accept: application/json' \
+                   --header "Authorization: ${REPLICATED_API_TOKEN}" \
+                | jq --raw-output --arg slug ${REPLICATED_APP} '.apps[] | select ( .slug == $slug ) | .id')"
+      spec_gzip="$(jq --compact --null-input --arg chart ${chart} --rawfile content <(base64 -w 0 ${chart}) '[ {"name": $chart, "path": $chart, "content": $content}]' | \
+        | gzip --to-stdout \
+        | base64 -w 0)"
+      sequence="$(curl --location "https://api.replicated.com/vendor/v3/app/${app_id}/release" \
+                    --header 'Content-Type: application/json' \
+                    --header 'Accept: application/json' \
+                    --header "Authorization: ${REPLICATED_API_TOKEN}" \
+                    --data "$(jq --compact --null-input --arg spec_gzip "${spec_gzip}" '{ "spec_gzip", $spec_gzip }')" \
+                  | jq '{ "sequence": .sequence }')"
+      echo "SEQUENCE=${sequence}" > release.env
+  artifacts:
+    reports:
+      dotenv: release.env
+  
 
 'Promote Release':      # Promote the release to the appropriate channel
   stage: promote
   dependencies:
     - 'Create Release'
-  service: 
+  image: 
     name: replicated/vendor-cli:latest
     entrypoint: [""] # This is a must. Entrypoint must be overriden to allow the script part to work. Script can not be skipped for the pipeline spec.
   script:
-    - /replicated release promote 
+    - /replicated release promote ${SEQUENCE} ${CI_COMMIT_REF_NAME}
 
 


### PR DESCRIPTION
TL;DR
-----

Adds CD pipelines for GitHub and GitLab

Details
-------

Implements initial CD capabilities using a GitHub Actions workflow and GitLab
CI/CD. This is a baseline to add more pipelines as we encounter customers who
use different CI/CD platforms.

The GitLab pipeline is a bit more complicated than it needs to be because the
current implementation of the `replicated` CLI makes it difficult to script out
scenarios where you split releasing from promoting. I opted to do that for
both the visual impact and because it is a more aligned with the idea of
testing a release _before_ releasing it, which we'll do in the next iteration.
